### PR TITLE
Fix "undefined: beego.LevelInfo" in conf.go.

### DIFF
--- a/setting/conf.go
+++ b/setting/conf.go
@@ -167,7 +167,7 @@ func LoadConfig() *goconfig.ConfigFile {
 
 	IsProMode = beego.RunMode == "pro"
 	if IsProMode {
-		beego.SetLevel(beego.LevelInfo)
+		beego.SetLevel(beego.LevelInformational)
 	}
 
 	// cache system


### PR DESCRIPTION
Fixes go/src/github.com/beego/wetalk/setting/conf.go:170: undefined: beego.LevelInfo.
