### PR TITLE
Removed beego.Info("AppPath:", beego.AppPath) from wetalk.go, since A…

### DIFF
--- a/wetalk.go
+++ b/wetalk.go
@@ -56,8 +56,6 @@ func main() {
 
 	initialize()
 
-	beego.Info("AppPath:", beego.AppPath)
-
 	if setting.IsProMode {
 		beego.Info("Product mode enabled")
 	} else {


### PR DESCRIPTION
Since AppPath is removed from beego, we need to update wetalk accordingly.