### PR TITLE
fix(#48) fix undefined: beego.BeeTemplates

### DIFF
--- a/modules/utils/template.go
+++ b/modules/utils/template.go
@@ -134,10 +134,7 @@ func RenderTemplate(TplNames string, Data map[interface{}]interface{}) string {
 	}
 
 	ibytes := bytes.NewBufferString("")
-	if _, ok := beego.BeeTemplates[TplNames]; !ok {
-		panic("can't find templatefile in the path:" + TplNames)
-	}
-	err := beego.BeeTemplates[TplNames].ExecuteTemplate(ibytes, TplNames, Data)
+	err := beego.ExecuteTemplate(ibytes, TplNames, Data)
 	if err != nil {
 		beego.Trace("template Execute err:", err)
 	}


### PR DESCRIPTION
fix this err:
```
# github.com/beego/wetalk/modules/utils
modules\utils\template.go:137: undefined: beego.BeeTemplates
modules\utils\template.go:140: undefined: beego.BeeTemplates
```